### PR TITLE
Move context out of LifeSpan and into Parameter

### DIFF
--- a/lifespan.go
+++ b/lifespan.go
@@ -11,15 +11,11 @@ import (
 
 // Runnable defines the behavior of a runnable task.
 type Runnable interface {
-	Run(span *LifeSpan)
+	Run(ctx context.Context, span *LifeSpan)
 }
 
 // LifeSpan holds the communication channels and context for a runnable task.
 type LifeSpan struct {
-	// UUID identifies the Lifespan for a Job. Useful for attributing logs and errors to jobs.
-	UUID string
-	// GroupID identifies the group this LifeSpan belongs to, if any.
-	GroupID string
 	// Sig and Ack are the primary control channels. Write to Sig to signal to close, and read from Ack to acknowledge.
 	Sig, Ack chan struct{}
 	// ErrBus is an implementation of MessageBus[any T] which is shared across all Runnable implementations.
@@ -27,9 +23,6 @@ type LifeSpan struct {
 	// Logger is a unique log/slog.Logger for a lifespan. Lifespan's share a base log handler so that they may write to the same
 	// underlying LogBus.
 	Logger *slog.Logger
-	// Context information for timeouts and cancels
-	Ctx    context.Context
-	Cancel context.CancelFunc
 }
 
 // Close will signal a runnable task to shutdown. If an acknowledgement is not given
@@ -51,7 +44,7 @@ func (span *LifeSpan) Close() {
 
 // Run runs the passed in job and returns a pointer to a LifeSpan.
 // If groupID is empty, no group_id attribute will be added to the logger.
-func Run(groupID string, logHandler slog.Handler, errBus MessageBus[Error], job func(span *LifeSpan)) (*LifeSpan, error) {
+func Run(ctx context.Context, logHandler slog.Handler, errBus MessageBus[Error], job func(ctx context.Context, span *LifeSpan)) (*LifeSpan, error) {
 
 	// logHandler and errBus cannot be nil.
 	if logHandler == nil {
@@ -62,44 +55,49 @@ func Run(groupID string, logHandler slog.Handler, errBus MessageBus[Error], job 
 		return nil, errors.New("nil errBus")
 	}
 
-	id := uuid.New()
-
-	// include job_id in logger created from logHandler
-	l := slog.New(logHandler)
-	l = l.With(slog.String("job_id", id.String()))
-
-	if groupID != "" {
-		l = l.With(slog.String("group_id", groupID))
+	// if the context does not contain a job_id then create and set one.
+	if _, ok := ctx.Value(jobIDKey).(string); !ok {
+		ctx = context.WithValue(ctx, jobIDKey, uuid.New().String())
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	// The context should contain the job_id and possibly the group_id and is the source of truth for these values.
+	// Create a new Logger from the logHandler and set the job_id and group_id attributes.
+	// This provides a fallback to ensure that we have these values in logs regardless if the user chooses to log with context.
+	l := slog.New(logHandler)
+	if id, ok := ctx.Value(jobIDKey).(string); ok {
+		l = l.With(slog.String(jobIDKey, id))
+	}
+	if id, ok := ctx.Value(groupIDKey).(string); ok {
+		l = l.With(slog.String(groupIDKey, id))
+	}
+
 	span := &LifeSpan{
-		UUID:    id.String(),
-		GroupID: groupID,
-		Sig:     make(chan struct{}, 1),
-		Ack:     make(chan struct{}, 1),
-		ErrBus:  errBus,
-		Logger:  l,
-		Ctx:     ctx,
-		Cancel:  cancel,
+		Sig:    make(chan struct{}, 1),
+		Ack:    make(chan struct{}, 1),
+		ErrBus: errBus,
+		Logger: l,
 	}
 
 	go func() {
 		defer close(span.Ack)
-		defer cancel()
-		job(span)
+		job(ctx, span)
 	}()
 
 	return span, nil
 }
 
 // Error shortcuts publishing to the ErrBus and inserts the JobID, GroupID, and timestamp into the Error.
-func (span *LifeSpan) Error(err error) {
+func (span *LifeSpan) Error(ctx context.Context, err error) {
 	e := Error{
-		JobID:     span.UUID,
-		GroupID:   span.GroupID,
 		Error:     err,
 		Timestamp: time.Now().UTC(),
 	}
+	if jid, ok := ctx.Value(jobIDKey).(string); ok {
+		e.JobID = jid
+	}
+	if gid, ok := ctx.Value(groupIDKey).(string); ok {
+		e.GroupID = gid
+	}
+
 	span.ErrBus.Publish(e)
 }


### PR DESCRIPTION
Instead of having the context stored within the LifeSpan of a job, this
change moves it to be a paramter that is passed around to the job on
creation. The context also now includes the Job ID and Group ID if
applicable.
